### PR TITLE
Support api-spec  changes in 2022.10.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ out/
 build/
 
 missing_stuff1.txt
+
+src/main/resources/api-specification/data

--- a/src/main/java/com/synopsys/integration/create/apigen/data/ClassCategories.java
+++ b/src/main/java/com/synopsys/integration/create/apigen/data/ClassCategories.java
@@ -49,6 +49,7 @@ public class ClassCategories {
         populate(COMMON, ClassSourceEnum.NULL, "Number");
         populate(COMMON, ClassSourceEnum.NULL, "null");
         populate(COMMON, ClassSourceEnum.NULL, "");
+        populate(COMMON, ClassSourceEnum.NULL, "com.google.gson.JsonObject");
 
         populate(VIEW, GENERATED, "AnnouncementBannerView");
         populate(VIEW, GENERATED, "CodeLocationView");

--- a/src/main/java/com/synopsys/integration/create/apigen/data/NameAndPathManager.java
+++ b/src/main/java/com/synopsys/integration/create/apigen/data/NameAndPathManager.java
@@ -38,7 +38,9 @@ public class NameAndPathManager {
         return apiDiscoveryData;
     }
 
-    public void addApiDiscoveryData(ApiPathData data) { apiDiscoveryData.add(data); }
+    public void addApiDiscoveryData(ApiPathData data) {
+        apiDiscoveryData.add(data);
+    }
 
     public boolean isRepeatApiDiscoveryPath(String path) {
         return apiDiscoveryDataPaths.contains(path);

--- a/src/main/java/com/synopsys/integration/create/apigen/data/UtilStrings.java
+++ b/src/main/java/com/synopsys/integration/create/apigen/data/UtilStrings.java
@@ -59,6 +59,7 @@ public class UtilStrings {
     public static final String OBJECT = "Object";
     public static final String INTEGER = "Integer";
     public static final String JAVA_DATE = "java.util.Date";
+    public static final String JSON_OBJECT = "com.google.gson.JsonObject";
 
     public static final String LINKS = "links";
     public static final String FIELDS = "fields";
@@ -78,7 +79,7 @@ public class UtilStrings {
     public static final String[] DIGIT_STRINGS = { "1", "2", "3", "4", "5", "6", "7", "8", "9" };
 
     public static Set<String> getJavaKeyWords() {
-        final Set<String> javaKeyWords = new HashSet<>();
+        Set<String> javaKeyWords = new HashSet<>();
 
         javaKeyWords.add("default");
         javaKeyWords.add("package");
@@ -88,7 +89,7 @@ public class UtilStrings {
     }
 
     public static Set<String> getDateSuffixes() {
-        final Set<String> dateSuffixes = new HashSet<>();
+        Set<String> dateSuffixes = new HashSet<>();
 
         dateSuffixes.add("edOn");
         dateSuffixes.add("edAt");

--- a/src/main/java/com/synopsys/integration/create/apigen/generation/generators/ComponentGenerator.java
+++ b/src/main/java/com/synopsys/integration/create/apigen/generation/generators/ComponentGenerator.java
@@ -47,7 +47,7 @@ public class ComponentGenerator extends ClassGenerator {
 
     @Autowired
     public ComponentGenerator(ClassCategories classCategories, ImportFinder importFinder, InputDataFinder inputDataFinder, NameAndPathManager nameAndPathManager, TypeTranslator typeTranslator, FilePathUtil filePathUtil,
-        GeneratorDataManager generatorDataManager, final DeprecatedClassGenerator deprecatedClassGenerator) {
+        GeneratorDataManager generatorDataManager, DeprecatedClassGenerator deprecatedClassGenerator) {
         this.classCategories = classCategories;
         this.importFinder = importFinder;
         this.inputDataFinder = inputDataFinder;
@@ -60,25 +60,25 @@ public class ComponentGenerator extends ClassGenerator {
 
     @Override
     public boolean isApplicable(FieldDefinition field) {
-        final String fieldType = NameParser.stripListNotation(field.getType());
-        final ClassCategoryData classCategoryData = classCategories.computeData(fieldType);
-        final ClassTypeEnum classType = classCategoryData.getType();
-        final ClassSourceEnum classSource = classCategoryData.getSource();
+        String fieldType = NameParser.stripListNotation(field.getType());
+        ClassCategoryData classCategoryData = classCategories.computeData(fieldType);
+        ClassTypeEnum classType = classCategoryData.getType();
+        ClassSourceEnum classSource = classCategoryData.getSource();
         return classType.isNotCommonTypeOrEnum() && !classSource.isTemporary() && !classSource.isManual() && !field.typeWasOverrided();
     }
 
     @Override
     public void generateClass(FieldDefinition field, String responseMediaType, Template template) {
-        final Set<String> imports = new HashSet<>();
-        final Set<FieldDefinition> subFields = field.getSubFields();
-        for (final FieldDefinition subField : subFields) {
+        Set<String> imports = new HashSet<>();
+        Set<FieldDefinition> subFields = field.getSubFields();
+        for (FieldDefinition subField : subFields) {
             imports.addAll(importFinder.findFieldImports(subField.getType()));
         }
 
         String fieldType = NameParser.stripListAndOptionalNotation(field.getType());
-        final ClassTypeEnum classType = classCategories.computeData(fieldType).getType();
+        ClassTypeEnum classType = classCategories.computeData(fieldType).getType();
         ClassTypeData classTypeData = new ClassTypeData(classType, filePathUtil);
-        final Map<String, Object> input = inputDataFinder.getInputData(classTypeData, imports, fieldType, subFields, responseMediaType);
+        Map<String, Object> input = inputDataFinder.getInputData(classTypeData, imports, fieldType, subFields, responseMediaType);
 
         if (isApplicable(field)) {
             String deprecatedName = typeTranslator.getNameOfDeprecatedEquivalent(fieldType);

--- a/src/main/java/com/synopsys/integration/create/apigen/parser/FieldDataProcessor.java
+++ b/src/main/java/com/synopsys/integration/create/apigen/parser/FieldDataProcessor.java
@@ -44,6 +44,12 @@ public class FieldDataProcessor {
         if (javaKeyWords.contains(path)) {
             path = path + "_";
         }
+
+        // Some endpoints support a raw json body. We should rename the field to reflect a wildcard
+        if (path.equals("*")) {
+            path = "jsonObject";
+        }
+
         return path.replace("[]", "");
     }
 
@@ -102,6 +108,11 @@ public class FieldDataProcessor {
             } else {
                 processedType = UtilStrings.JAVA_LIST + coreType + ">";
             }
+        }
+
+        // Fields marked with a wildcard indicate that the accepted type is raw json
+        if (rawFieldDefinition.getPath().equals("*")) {
+            processedType = UtilStrings.JSON_OBJECT;
         }
 
         return processedType;

--- a/src/main/java/com/synopsys/integration/create/apigen/parser/file/DirectoryPathParser.java
+++ b/src/main/java/com/synopsys/integration/create/apigen/parser/file/DirectoryPathParser.java
@@ -22,10 +22,10 @@ import org.springframework.stereotype.Component;
 
 import com.google.gson.Gson;
 import com.synopsys.integration.create.apigen.data.DuplicateOverrides;
-import com.synopsys.integration.create.apigen.data.mediatype.MediaTypes;
 import com.synopsys.integration.create.apigen.data.MissingFieldsAndLinks;
 import com.synopsys.integration.create.apigen.data.TypeTranslator;
 import com.synopsys.integration.create.apigen.data.UtilStrings;
+import com.synopsys.integration.create.apigen.data.mediatype.MediaTypes;
 import com.synopsys.integration.create.apigen.model.DefinitionParseParameters;
 import com.synopsys.integration.create.apigen.model.FieldDefinition;
 import com.synopsys.integration.create.apigen.model.LinkDefinition;
@@ -52,7 +52,7 @@ public class DirectoryPathParser implements ApiParser {
     private final FieldDefinitionProcessor processor;
 
     @Autowired
-    public DirectoryPathParser(final Gson gson, final TypeTranslator typeTranslator, final NameParser nameParser, final MissingFieldsAndLinks missingFieldsAndLinks,
+    public DirectoryPathParser(Gson gson, TypeTranslator typeTranslator, NameParser nameParser, MissingFieldsAndLinks missingFieldsAndLinks,
         FieldDefinitionProcessor processor) {
         this.gson = gson;
         this.typeTranslator = typeTranslator;
@@ -63,19 +63,19 @@ public class DirectoryPathParser implements ApiParser {
 
     @Override
     public List<ResponseDefinition> parseApi(File specificationRootDirectory, MediaTypes mediaTypes) {
-        final File endpointsPath = new File(specificationRootDirectory, "endpoints");
-        final File apiPath = new File(endpointsPath, UtilStrings.API);
+        File endpointsPath = new File(specificationRootDirectory, "endpoints");
+        File apiPath = new File(endpointsPath, UtilStrings.API);
 
         List<ResponseDefinition> responseDefinitions = new LinkedList<>();
         List<ResponseDefinition> allResponseDefinitions = parseApiForAllResponses(apiPath, apiPath.getAbsolutePath().length() + 1, mediaTypes);
 
         // For each response file, parse the JSON for FieldDefinition objects
-        for (final ResponseDefinition response : allResponseDefinitions) {
-            final String absolutePath = specificationRootDirectory.getAbsolutePath() + "/endpoints/api/" + response.getResponseSpecificationPath();
-            final File responseSpecificationFile = new File(absolutePath);
-            final DefinitionParser definitionParser = new DefinitionParser(gson, responseSpecificationFile);
-            final Set<RawFieldDefinition> fields = definitionParser.getDefinitions(DefinitionParseParameters.RAW_FIELD_PARAMETERS);
-            final Set<LinkDefinition> links = definitionParser.getDefinitions(DefinitionParseParameters.LINK_PARAMETERS);
+        for (ResponseDefinition response : allResponseDefinitions) {
+            String absolutePath = specificationRootDirectory.getAbsolutePath() + "/endpoints/api/" + response.getResponseSpecificationPath();
+            File responseSpecificationFile = new File(absolutePath);
+            DefinitionParser definitionParser = new DefinitionParser(gson, responseSpecificationFile);
+            Set<RawFieldDefinition> fields = definitionParser.getDefinitions(DefinitionParseParameters.RAW_FIELD_PARAMETERS);
+            Set<LinkDefinition> links = definitionParser.getDefinitions(DefinitionParseParameters.LINK_PARAMETERS);
 
             response.addFields(processor.processFieldDefinitions(response.getName(), fields));
             response.addLinks(links);
@@ -84,7 +84,7 @@ public class DirectoryPathParser implements ApiParser {
             ResponseType responseType = ResponseTypeIdentifier.getResponseType(response);
             if (responseType.equals(ResponseType.DATA_IS_SUBFIELD_OF_ITEMS)) {
                 responseDefinitions.add(extractResponseFromSubfieldsOfItems(response));
-            } else if (!responseType.equals(ResponseType.ARRAY)){
+            } else if (!responseType.equals(ResponseType.ARRAY)) {
                 responseDefinitions.add(response);
             }
         }
@@ -92,12 +92,12 @@ public class DirectoryPathParser implements ApiParser {
         return responseDefinitions;
     }
 
-    private List<ResponseDefinition> parseApiForAllResponses(final File parent, final int prefixLength, MediaTypes mediaTypes) {
+    private List<ResponseDefinition> parseApiForAllResponses(File parent, int prefixLength, MediaTypes mediaTypes) {
         List<ResponseDefinition> responseDefinitions = new LinkedList<>();
-        final List<File> files = Arrays.stream(parent.listFiles())
-                                        .filter(file -> !file.getName().equals("notifications"))
-                                        .sorted()
-                                        .collect(Collectors.toList());
+        List<File> files = Arrays.stream(parent.listFiles())
+                               .filter(file -> !file.getName().equals("notifications"))
+                               .sorted()
+                               .collect(Collectors.toList());
         for (File file : files) {
             if (file.getName().equals(RESPONSE_ENDPOINT_TOKEN)) {
                 Optional<File> responseSpecificationWithLatestMediaVersion = findResponseSpecificationWithLatestMediaVersion(file);
@@ -137,27 +137,27 @@ public class DirectoryPathParser implements ApiParser {
     }
 
     private ResponseDefinition createResponseDefinitionFromSpecification(File responseSpecification, int prefixLength, MediaTypes mediaTypes) {
-        final String relativePath = responseSpecification.getAbsolutePath().substring(prefixLength);
-        final String mediaType = mediaTypes.getLongName(responseSpecification.getParentFile().getName());
-        final String responseName = nameParser.computeResponseName(relativePath);
-        final boolean doesHaveMultipleResults = computeIfHasMultipleResults(responseSpecification);
+        String relativePath = responseSpecification.getAbsolutePath().substring(prefixLength);
+        String mediaType = mediaTypes.getLongName(responseSpecification.getParentFile().getName());
+        String responseName = nameParser.computeResponseName(relativePath);
+        boolean doesHaveMultipleResults = computeIfHasMultipleResults(responseSpecification);
         return new ResponseDefinition(relativePath, responseName, mediaType, doesHaveMultipleResults);
     }
 
-    private boolean computeIfHasMultipleResults(final File file) {
+    private boolean computeIfHasMultipleResults(File file) {
         /*
             Whether a response has single or multiple results is indicated by the presence of an 'Array' response specification file
             as a sibling to the parent directory of another response specification file.  If such a file does not exist, then that
             response does not have multiple results.
          */
-        final File parentOfArrayResponse = getParentOfArrayResponse(file);
+        File parentOfArrayResponse = getParentOfArrayResponse(file);
         if (parentOfArrayResponse == null) {
             return false;
         }
         return containsArrayResponse(parentOfArrayResponse, false);
     }
 
-    private File getParentOfArrayResponse(final File file) {
+    private File getParentOfArrayResponse(File file) {
         /*
             The location of an indicating 'Array' response in the file structure is such:
                 <endpoint>
@@ -171,7 +171,7 @@ public class DirectoryPathParser implements ApiParser {
         while (!current.getName().equals(UtilStrings.GET)) {
             current = current.getParentFile();
         }
-        final File getFile = current;
+        File getFile = current;
         current = getFile.getParentFile();
         if (current.getParentFile() != null && !current.getParentFile().getName().equals(UtilStrings.API)) {
             return current.getParentFile();
@@ -180,20 +180,24 @@ public class DirectoryPathParser implements ApiParser {
         }
     }
 
-    private boolean containsArrayResponse(final File file, final boolean isGetFileSubDirectory) {
-        final File[] children = file.listFiles();
+    private boolean containsArrayResponse(File file, boolean isGetFileSubDirectory) {
+        File[] children = file.listFiles();
         if (children == null) {
             return false;
         }
-        for (final File child : children) {
+        boolean foundArrayResponse = false;
+        for (File child : children) {
             if (child.getName().equals(UtilStrings.RESPONSE_SPECIFICATION_JSON)) {
-                final ResponseDefinition potentialArrayResponse = buildDummyResponseDefinitionFromFile(child);
+                ResponseDefinition potentialArrayResponse = buildDummyResponseDefinitionFromFile(child);
                 if (!ResponseTypeIdentifier.getResponseType(potentialArrayResponse).equals(ResponseType.STANDARD)) {
                     return true;
                 }
             }
             if (child.getName().equals(UtilStrings.GET) || (isGetFileSubDirectory && !child.getName().equals(UtilStrings.REQUEST_SPECIFICATION_JSON))) {
-                return containsArrayResponse(child, true);
+                foundArrayResponse = containsArrayResponse(child, true);
+            }
+            if (foundArrayResponse) {
+                return true;
             }
         }
         return false;
@@ -212,12 +216,12 @@ public class DirectoryPathParser implements ApiParser {
         return newResponse;
     }
 
-    private ResponseDefinition buildDummyResponseDefinitionFromFile(final File file) {
-        final DefinitionParser definitionParser = new DefinitionParser(gson, file);
-        final Set<RawFieldDefinition> rawFieldDefinitions = definitionParser.getDefinitions(DefinitionParseParameters.RAW_FIELD_PARAMETERS);
+    private ResponseDefinition buildDummyResponseDefinitionFromFile(File file) {
+        DefinitionParser definitionParser = new DefinitionParser(gson, file);
+        Set<RawFieldDefinition> rawFieldDefinitions = definitionParser.getDefinitions(DefinitionParseParameters.RAW_FIELD_PARAMETERS);
         FieldDefinitionProcessor processor = new FieldDefinitionProcessor(new FieldDataProcessor(typeTranslator, new DuplicateTypeIdentifier(new DuplicateOverrides())), missingFieldsAndLinks);
-        final Set<FieldDefinition> fieldDefinitions = processor.processFieldDefinitions("", rawFieldDefinitions);
-        final ResponseDefinition response = new ResponseDefinition("", "", "", false);
+        Set<FieldDefinition> fieldDefinitions = processor.processFieldDefinitions("", rawFieldDefinitions);
+        ResponseDefinition response = new ResponseDefinition("", "", "", false);
         response.addFields(fieldDefinitions);
         return response;
     }

--- a/src/test/java/com/synopsys/integration/create/apigen/parser/FieldDataProcessorTest.java
+++ b/src/test/java/com/synopsys/integration/create/apigen/parser/FieldDataProcessorTest.java
@@ -11,10 +11,10 @@ import com.synopsys.integration.create.apigen.data.DuplicateOverrides;
 import com.synopsys.integration.create.apigen.data.TypeTranslator;
 import com.synopsys.integration.create.apigen.model.RawFieldDefinition;
 
-public class FieldDataProcessorTest {
+class FieldDataProcessorTest {
 
     @Test
-    public void testCorrectProcessedType() {
+    void testCorrectProcessedType() {
         RawFieldDefinition object1 = new RawFieldDefinition("createdAt", "type", false);
         assertHasExpectedType(object1, "", "java.util.Date");
 
@@ -35,10 +35,19 @@ public class FieldDataProcessorTest {
         object6.addSubField(new RawFieldDefinition("", "", false));
         assertHasExpectedType(object6, "ProjectView", "java.util.List<ProjectCountsView>");
 
+        RawFieldDefinition object7 = new RawFieldDefinition("counts[]", "Array", false);
+        object7.addSubField(new RawFieldDefinition("", "", false));
+        assertHasExpectedType(object7, "ProjectView", "java.util.List<ProjectCountsView>");
+
+        // 2 dimensional array test
+        RawFieldDefinition object8 = new RawFieldDefinition("dependencyTrees[][]", "Array", false);
+        object8.addSubField(new RawFieldDefinition("", "", false));
+        assertHasExpectedType(object8, "ProjectView", "java.util.List<java.util.List<ProjectDependencyTreesView>>");
+
     }
 
     @Test
-    public void testCorrectProcessedPath() {
+    void testCorrectProcessedPath() {
         RawFieldDefinition object1 = new RawFieldDefinition("default", "type", false);
         assertHasExpectedPath(object1, "", "default_");
 


### PR DESCRIPTION
The goal of these changes was to fix issues discovered when attempting to create the 2022.10.0 upgrade for blackduck-common-api.

The issues resolved:

- Support wildcard notation for endpoints by replacing the fields with a JsonObject
- Handle multi-dimensional arrays for response objects
- Fix a bug in the the path parser that would not loop through all subdirectories of an endpoint due to terminating the recursion early